### PR TITLE
Fix Numerical -ne does not dereference in ...

### DIFF
--- a/git_diff_image
+++ b/git_diff_image
@@ -68,7 +68,7 @@ if [ -n "${GIT_DIFF_IMAGE_OUTPUT_DIR-}" ]
 then
     mkdir -p "$GIT_DIFF_IMAGE_OUTPUT_DIR"
     destfile=''
-    if [ "$name1" -ne '/dev/null' ]
+    if [ "$name1" = '/dev/null' ]
     then
         destfile=$(basename "$name1")
     else


### PR DESCRIPTION
It fixes this finding

![image](https://user-images.githubusercontent.com/3314607/209065283-3890eca0-5d56-4fe0-ad09-162591967f1b.png)

It's untested and I'm not 100% sure if it's right. I just followed the syntax in https://github.com/ewanmellor/git-diff-image/blob/master/git_diff_image#L12 

`if [ "$f1" = /dev/null ]`