### PR TITLE
Add GraphicMagick compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ $ diff-image anImageThatHasChanged1.jpg anImageThatHasChanged2.jpg
 Installation
 ------------
 
-1. Install exiftool and ImageMagick.  (The script will cope with these missing,
-but it's not going to be very exciting without them).
+1. Install exiftool and ImageMagick or ImageMagick with the compatibility links.
+(The script will cope with these missing, but it's not going to be very exciting
+without them).
 
    macOS:
 
@@ -57,7 +58,12 @@ but it's not going to be very exciting without them).
    ```bash
    sudo apt install exiftool imagemagick xdg-open
    ```
-   
+
+   Debian / Ubuntu (if using GraphicsMagick):
+   ```bash
+   sudo apt install exiftool graphicsmagick graphicsmagick-imagemagick-compat xdg-utils
+   ```
+
    Arch Linux:
   
    ```bash

--- a/diff-image
+++ b/diff-image
@@ -161,7 +161,16 @@ if \
     ! which compare > /dev/null || \
     ! which montage > /dev/null
 then
-    echo 'ImageMagick is not installed.' >&2
+    if which gm > /dev/null
+    then
+        echo 'GraphicsMagick is installed, but graphicsmagick-imagemagick-compat missing.' >&2
+        echo 'Alternatively the minimum required compatibility links can be installed' >&2
+        echo 'by running:' >&2
+        echo '    sudo ln -s gm /usr/bin/compare' >&2
+        echo '    sudo ln -s gm /usr/bin/montage' >&2
+    else
+        echo 'ImageMagick or GraphicsMagick is not installed.' >&2
+    fi
     exit 1
 fi
 
@@ -199,8 +208,15 @@ fi
 density_flag=
 do_compare()
 {
+  if which gm > /dev/null
+  then
+    echo "NOTICE: GraphicsMagick does not support 'compare -fuzz', so omitting it"
+    compare $density_flag $color_flag $backgroundcolor_flag -file png:- "$f1" "$f2" | \
+        montage $density_flag -geometry +4+4 $backgroundcolor_flag "$f1" - "$f2" png:- >"$destfile" 2>/dev/null || true
+  else
     compare $density_flag $color_flag $fuzz_flag $backgroundcolor_flag "$f1" "$f2" png:- | \
         montage $density_flag -geometry +4+4 $backgroundcolor_flag "$f1" - "$f2" png:- >"$destfile" 2>/dev/null || true
+  fi
 }
 
 if which xdg-open > /dev/null


### PR DESCRIPTION
GraphicMagick branched off ImageMagick's version 5.5.2 in 2002 after irreconcilable differences emerged in the developers' group.[1]

Some systems might have GraphicMagick and diff-image works just fine with it, so add a few lines to automatically support it as well, but expect users to install the compatibility package that adds the symlinks for commands 'compare' and 'montage'.

[1] https://en.wikipedia.org/wiki/GraphicsMagick

Closes: #37