### PR TITLE
Show binary diff if exif has no diff

### DIFF
--- a/diff-image
+++ b/diff-image
@@ -134,7 +134,7 @@ exif()
 
 diff_clean_names()
 {
-    diff -u "$1" --label "$name1" "$2" --label "$name2" || true
+    diff -u "$1" --label "$name1" "$2" --label "$name2"
 }
 
 
@@ -143,13 +143,13 @@ if which exiftool > /dev/null
 then
   d1="$(exif "$f1")"
   d2="$(exif "$f2")"
-  diff_clean_names "$d1" "$d2"
+  diff_clean_names "$d1" "$d2" && diff_clean_names "$f1" "$f2" || true
   set +e
   diff -q "$d1" "$d2" >/dev/null
   exifdiff=$?
   set -e
 else
-  diff_clean_names "$f1" "$f2"
+  diff_clean_names "$f1" "$f2" || true
 fi
 
 if $exif_only


### PR DESCRIPTION
Fixes #40

## Before this change

If an image file differs, but its exif information is unchanged, `git diff` produces no output.

## After this change

If an image file differs, but its exif information is unchanged, `git diff` produces the following output:
```
Binary files a/path/to/image.png and b/path/to/image.png differ
```