### PR TITLE
diff --color=auto

### DIFF
--- a/diff-image
+++ b/diff-image
@@ -134,7 +134,7 @@ exif()
 
 diff_clean_names()
 {
-    diff -u "$1" --label "$name1" "$2" --label "$name2" || true
+    diff --color=auto -u "$1" --label "$name1" "$2" --label "$name2" || true
 }
 
 


### PR DESCRIPTION
In my system (Ubuntu 23.10) /usr/bin/diff displays no color by default.

An alternative could be to create another `diff` in $PATH. 
